### PR TITLE
docs: Executorに関する契約を, 次世代バージョン用に修正

### DIFF
--- a/src/matsu/num/transform/fft/DFTExecutor.java
+++ b/src/matsu/num/transform/fft/DFTExecutor.java
@@ -5,12 +5,11 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.5.8
+ * 2025.6.20
  */
 package matsu.num.transform.fft;
 
 import matsu.num.transform.fft.dto.ComplexNumberArrayDTO;
-import matsu.num.transform.fft.validation.StructureAcceptance;
 
 /**
  * 離散Fourier変換 (DFT) を扱う.
@@ -24,7 +23,7 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
  * </p>
  * 
  * <p>
- * このインターフェースにおいて,
+ * このインターフェースでは,
  * {@link #accepts(ComplexNumberArrayDTO)}
  * のreject条件は,
  * {@link ComplexLinearTransform}
@@ -61,18 +60,5 @@ public interface DFTExecutor extends ComplexLinearTransform {
      * 扱うことができるデータサイズの最大値: 2<sup>28</sup>
      */
     public static final int MAX_DATA_SIZE = 0x1000_0000;
-
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link DFTExecutor} ではデータサイズが {@link #MAX_DATA_SIZE}
-     * を超過する場合にrejectされる.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(ComplexNumberArrayDTO complexNumberArray);
 
 }

--- a/src/matsu/num/transform/fft/GenericDFTExecutor.java
+++ b/src/matsu/num/transform/fft/GenericDFTExecutor.java
@@ -7,7 +7,6 @@
 package matsu.num.transform.fft;
 
 import matsu.num.transform.fft.dto.ComplexNumberArrayDTO;
-import matsu.num.transform.fft.validation.StructureAcceptance;
 
 /**
  * 任意のデータサイズに適用可能なDFT.
@@ -35,15 +34,4 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
 @Deprecated(forRemoval = true)
 public interface GenericDFTExecutor extends DFTExecutor {
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link GenericDFTExecutor} でaccept条件とreject条件が共に確定 (固定) される.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(ComplexNumberArrayDTO complexNumberArray);
 }

--- a/src/matsu/num/transform/fft/GenericIDFTExecutor.java
+++ b/src/matsu/num/transform/fft/GenericIDFTExecutor.java
@@ -7,7 +7,6 @@
 package matsu.num.transform.fft;
 
 import matsu.num.transform.fft.dto.ComplexNumberArrayDTO;
-import matsu.num.transform.fft.validation.StructureAcceptance;
 
 /**
  * 任意のデータサイズに適用可能なIDFT.
@@ -35,15 +34,4 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
 @Deprecated(forRemoval = true)
 public interface GenericIDFTExecutor extends IDFTExecutor {
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link GenericIDFTExecutor} でaccept条件とreject条件が共に確定 (固定) される.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(ComplexNumberArrayDTO complexNumberArray);
 }

--- a/src/matsu/num/transform/fft/IDFTExecutor.java
+++ b/src/matsu/num/transform/fft/IDFTExecutor.java
@@ -10,7 +10,6 @@
 package matsu.num.transform.fft;
 
 import matsu.num.transform.fft.dto.ComplexNumberArrayDTO;
-import matsu.num.transform.fft.validation.StructureAcceptance;
 
 /**
  * 逆離散Fourier変換 (IDFT) を扱う.
@@ -24,7 +23,7 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
  * </p>
  * 
  * <p>
- * このインターフェースにおいて,
+ * このインターフェースでは,
  * {@link #accepts(ComplexNumberArrayDTO)}
  * のreject条件は,
  * {@link ComplexLinearTransform}
@@ -62,16 +61,4 @@ public interface IDFTExecutor extends ComplexLinearTransform {
      */
     public static final int MAX_DATA_SIZE = 0x1000_0000;
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link IDFTExecutor} ではデータサイズが {@link #MAX_DATA_SIZE}
-     * を超過する場合にrejectされる.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(ComplexNumberArrayDTO complexNumberArray);
 }

--- a/src/matsu/num/transform/fft/convolution/CyclicConvolutionExecutor.java
+++ b/src/matsu/num/transform/fft/convolution/CyclicConvolutionExecutor.java
@@ -5,12 +5,11 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.5.8
+ * 2025.6.20
  */
 package matsu.num.transform.fft.convolution;
 
 import matsu.num.transform.fft.BiLinearTransform;
-import matsu.num.transform.fft.validation.StructureAcceptance;
 
 /**
  * 実数列の巡回畳み込みを扱う.
@@ -32,7 +31,7 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
  * </p>
  * 
  * <p>
- * このインターフェースにおいて,
+ * このインターフェースでは,
  * {@link #accepts(double[], double[])}
  * のreject条件は,
  * {@link BiLinearTransform}
@@ -55,17 +54,4 @@ public interface CyclicConvolutionExecutor extends BiLinearTransform {
      */
     public static final int MAX_DATA_SIZE = 0x1000_0000;
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link CyclicConvolutionExecutor} ではデータサイズが
-     * {@link #MAX_DATA_SIZE}
-     * を超過する場合にrejectされる.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] f, double[] g);
 }

--- a/src/matsu/num/transform/fft/convolution/GenericCyclicConvolutionExecutor.java
+++ b/src/matsu/num/transform/fft/convolution/GenericCyclicConvolutionExecutor.java
@@ -6,8 +6,6 @@
  */
 package matsu.num.transform.fft.convolution;
 
-import matsu.num.transform.fft.validation.StructureAcceptance;
-
 /**
  * 任意のデータサイズに適用可能な実数列の巡回畳み込み.
  * 
@@ -15,8 +13,7 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
  * このインターフェースにおいて,
  * {@link #accepts(double[], double[])}
  * のreject条件は,
- * {@link CyclicConvolutionExecutor} と同等である. <br>
- * このインターフェースのサブタイプではこれ以上reject条件を緩めて (accept条件を強めて) いないことを保証する.
+ * {@link CyclicConvolutionExecutor} と同等である.
  * </p>
  * 
  * <p>
@@ -34,16 +31,4 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
 @Deprecated(forRemoval = true)
 public interface GenericCyclicConvolutionExecutor extends CyclicConvolutionExecutor {
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link GenericCyclicConvolutionExecutor} でaccept条件とreject条件が共に確定 (固定)
-     * される.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] f, double[] g);
 }

--- a/src/matsu/num/transform/fft/convolution/Power2CyclicConvolutionExecutor.java
+++ b/src/matsu/num/transform/fft/convolution/Power2CyclicConvolutionExecutor.java
@@ -6,8 +6,6 @@
  */
 package matsu.num.transform.fft.convolution;
 
-import matsu.num.transform.fft.validation.StructureAcceptance;
-
 /**
  * 2の累乗のデータサイズに特化した実数列の巡回畳み込み.
  * 
@@ -16,8 +14,7 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
  * {@link #accepts(double[], double[])}
  * のreject条件は,
  * {@link CyclicConvolutionExecutor}
- * に対して次が追加される. <br>
- * このインターフェースのサブタイプではこれ以上reject条件を緩めて (accept条件を強めて) いないことを保証する.
+ * に対して次が追加される.
  * </p>
  * 
  * <ul>
@@ -39,18 +36,4 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
 @Deprecated(forRemoval = true)
 public interface Power2CyclicConvolutionExecutor extends CyclicConvolutionExecutor {
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link Power2CyclicConvolutionExecutor}
-     * ではデータサイズが2の累乗でない場合にrejectされる. <br>
-     * {@link Power2CyclicConvolutionExecutor}
-     * でaccept条件とreject条件が共に確定 (固定) される.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] f, double[] g);
 }

--- a/src/matsu/num/transform/fft/dctdst/DCT1Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/DCT1Executor.java
@@ -5,12 +5,11 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.5.8
+ * 2025.6.20
  */
 package matsu.num.transform.fft.dctdst;
 
 import matsu.num.transform.fft.LinearTransform;
-import matsu.num.transform.fft.validation.StructureAcceptance;
 
 /**
  * タイプ1の離散cosine変換 (DCT-1) を扱う. <br>
@@ -27,7 +26,7 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
  * </p>
  * 
  * <p>
- * このインターフェースにおいて,
+ * このインターフェースでは,
  * {@link #accepts(double[])}
  * のreject条件は,
  * {@link LinearTransform}
@@ -100,17 +99,4 @@ public interface DCT1Executor extends LinearTransform {
      */
     public static final int MAX_DATA_SIZE = 0x1000_0000 / 2 + 1;
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link DCT1Executor} ではデータサイズが1の場合,
-     * {@link #MAX_DATA_SIZE}
-     * を超過する場合にrejectされる.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/DCT2Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/DCT2Executor.java
@@ -5,12 +5,11 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.5.8
+ * 2025.6.20
  */
 package matsu.num.transform.fft.dctdst;
 
 import matsu.num.transform.fft.LinearTransform;
-import matsu.num.transform.fft.validation.StructureAcceptance;
 
 /**
  * タイプ2の離散cosine変換 (DCT-2) を扱う.
@@ -24,7 +23,7 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
  * </p>
  * 
  * <p>
- * このインターフェースにおいて,
+ * このインターフェースでは,
  * {@link #accepts(double[])}
  * のreject条件は,
  * {@link LinearTransform}
@@ -92,17 +91,4 @@ public interface DCT2Executor extends LinearTransform {
      */
     public static final int MAX_DATA_SIZE = 0x1000_0000 / 2;
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link DCT2Executor} ではデータサイズが
-     * {@link #MAX_DATA_SIZE}
-     * を超過する場合にrejectされる.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/DCT3Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/DCT3Executor.java
@@ -5,12 +5,11 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.5.8
+ * 2025.6.20
  */
 package matsu.num.transform.fft.dctdst;
 
 import matsu.num.transform.fft.LinearTransform;
-import matsu.num.transform.fft.validation.StructureAcceptance;
 
 /**
  * タイプ3の離散cosine変換 (DCT-3) を扱う.
@@ -25,7 +24,7 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
  * </p>
  * 
  * <p>
- * このインターフェースにおいて,
+ * このインターフェースでは,
  * {@link #accepts(double[])}
  * のreject条件は,
  * {@link LinearTransform}
@@ -100,17 +99,4 @@ public interface DCT3Executor extends LinearTransform {
      */
     public static final int MAX_DATA_SIZE = 0x1000_0000 / 2;
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link DCT3Executor} ではデータサイズが
-     * {@link #MAX_DATA_SIZE}
-     * を超過する場合にrejectされる.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/DCT4Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/DCT4Executor.java
@@ -5,12 +5,11 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.5.8
+ * 2025.6.20
  */
 package matsu.num.transform.fft.dctdst;
 
 import matsu.num.transform.fft.LinearTransform;
-import matsu.num.transform.fft.validation.StructureAcceptance;
 
 /**
  * タイプ4の離散cosine変換 (DCT-4) を扱う.
@@ -25,7 +24,7 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
  * </p>
  * 
  * <p>
- * このインターフェースにおいて,
+ * このインターフェースでは,
  * {@link #accepts(double[])}
  * のreject条件は,
  * {@link LinearTransform}
@@ -96,17 +95,4 @@ public interface DCT4Executor extends LinearTransform {
      */
     public static final int MAX_DATA_SIZE = 0x1000_0000 / 2;
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link DCT4Executor} ではデータサイズが
-     * {@link #MAX_DATA_SIZE}
-     * を超過する場合にrejectされる.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/DST1Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/DST1Executor.java
@@ -5,12 +5,11 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.5.8
+ * 2025.6.20
  */
 package matsu.num.transform.fft.dctdst;
 
 import matsu.num.transform.fft.LinearTransform;
-import matsu.num.transform.fft.validation.StructureAcceptance;
 
 /**
  * タイプ1の離散sine変換 (DST-1) を扱う.
@@ -25,7 +24,7 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
  * </p>
  * 
  * <p>
- * このインターフェースにおいて,
+ * このインターフェースでは,
  * {@link #accepts(double[])}
  * のreject条件は,
  * {@link LinearTransform}
@@ -95,17 +94,4 @@ public interface DST1Executor extends LinearTransform {
      */
     public static final int MAX_DATA_SIZE = 0x1000_0000 / 2 - 1;
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link DST1Executor} ではデータサイズが
-     * {@link #MAX_DATA_SIZE}
-     * を超過する場合にrejectされる.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/DST2Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/DST2Executor.java
@@ -5,12 +5,11 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.5.8
+ * 2025.6.20
  */
 package matsu.num.transform.fft.dctdst;
 
 import matsu.num.transform.fft.LinearTransform;
-import matsu.num.transform.fft.validation.StructureAcceptance;
 
 /**
  * タイプ2の離散sine変換 (DST-2) を扱う.
@@ -25,7 +24,7 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
  * </p>
  * 
  * <p>
- * このインターフェースにおいて,
+ * このインターフェースでは,
  * {@link #accepts(double[])}
  * のreject条件は,
  * {@link LinearTransform}
@@ -94,17 +93,4 @@ public interface DST2Executor extends LinearTransform {
      */
     public static final int MAX_DATA_SIZE = 0x1000_0000 / 2;
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link DST2Executor} ではデータサイズが
-     * {@link #MAX_DATA_SIZE}
-     * を超過する場合にrejectされる.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/DST3Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/DST3Executor.java
@@ -5,12 +5,11 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.5.8
+ * 2025.6.20
  */
 package matsu.num.transform.fft.dctdst;
 
 import matsu.num.transform.fft.LinearTransform;
-import matsu.num.transform.fft.validation.StructureAcceptance;
 
 /**
  * タイプ3の離散sine変換 (DST-3) を扱う.
@@ -26,7 +25,7 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
  * </p>
  * 
  * <p>
- * このインターフェースにおいて,
+ * このインターフェースでは,
  * {@link #accepts(double[])}
  * のreject条件は,
  * {@link LinearTransform}
@@ -99,17 +98,4 @@ public interface DST3Executor extends LinearTransform {
      */
     public static final int MAX_DATA_SIZE = 0x1000_0000 / 2;
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link DST3Executor} ではデータサイズが
-     * {@link #MAX_DATA_SIZE}
-     * を超過する場合にrejectされる.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/DST4Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/DST4Executor.java
@@ -5,12 +5,11 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.5.8
+ * 2025.6.20
  */
 package matsu.num.transform.fft.dctdst;
 
 import matsu.num.transform.fft.LinearTransform;
-import matsu.num.transform.fft.validation.StructureAcceptance;
 
 /**
  * タイプ4の離散sine変換 (DST-4) を扱う.
@@ -25,7 +24,7 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
  * </p>
  * 
  * <p>
- * このインターフェースにおいて,
+ * このインターフェースでは,
  * {@link #accepts(double[])}
  * のreject条件は,
  * {@link LinearTransform}
@@ -96,17 +95,4 @@ public interface DST4Executor extends LinearTransform {
      */
     public static final int MAX_DATA_SIZE = 0x1000_0000 / 2;
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link DST4Executor} ではデータサイズが
-     * {@link #MAX_DATA_SIZE}
-     * を超過する場合にrejectされる.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/GenericDCT1Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/GenericDCT1Executor.java
@@ -6,8 +6,6 @@
  */
 package matsu.num.transform.fft.dctdst;
 
-import matsu.num.transform.fft.validation.StructureAcceptance;
-
 /**
  * 任意のデータサイズに適用可能なDCT-1.
  * 
@@ -34,15 +32,4 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
 @Deprecated(forRemoval = true)
 public interface GenericDCT1Executor extends DCT1Executor {
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link GenericDCT1Executor} でaccept条件とreject条件が共に確定 (固定) される.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/GenericDCT2Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/GenericDCT2Executor.java
@@ -6,8 +6,6 @@
  */
 package matsu.num.transform.fft.dctdst;
 
-import matsu.num.transform.fft.validation.StructureAcceptance;
-
 /**
  * 任意のデータサイズに適用可能なDCT-2.
  * 
@@ -34,15 +32,4 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
 @Deprecated(forRemoval = true)
 public interface GenericDCT2Executor extends DCT2Executor {
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link GenericDCT2Executor} でaccept条件とreject条件が共に確定 (固定) される.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/GenericDCT3Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/GenericDCT3Executor.java
@@ -6,8 +6,6 @@
  */
 package matsu.num.transform.fft.dctdst;
 
-import matsu.num.transform.fft.validation.StructureAcceptance;
-
 /**
  * 任意のデータサイズに適用可能なDCT-3.
  * 
@@ -34,15 +32,4 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
 @Deprecated(forRemoval = true)
 public interface GenericDCT3Executor extends DCT3Executor {
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link GenericDCT3Executor} でaccept条件とreject条件が共に確定 (固定) される.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/GenericDCT4Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/GenericDCT4Executor.java
@@ -6,8 +6,6 @@
  */
 package matsu.num.transform.fft.dctdst;
 
-import matsu.num.transform.fft.validation.StructureAcceptance;
-
 /**
  * 任意のデータサイズに適用可能なDCT-4.
  * 
@@ -34,15 +32,4 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
 @Deprecated(forRemoval = true)
 public interface GenericDCT4Executor extends DCT4Executor {
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link GenericDCT4Executor} でaccept条件とreject条件が共に確定 (固定) される.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/GenericDST1Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/GenericDST1Executor.java
@@ -6,8 +6,6 @@
  */
 package matsu.num.transform.fft.dctdst;
 
-import matsu.num.transform.fft.validation.StructureAcceptance;
-
 /**
  * 任意のデータサイズに適用可能なDST-1.
  * 
@@ -34,15 +32,4 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
 @Deprecated(forRemoval = true)
 public interface GenericDST1Executor extends DST1Executor {
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link GenericDST1Executor} でaccept条件とreject条件が共に確定 (固定) される.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/GenericDST2Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/GenericDST2Executor.java
@@ -6,8 +6,6 @@
  */
 package matsu.num.transform.fft.dctdst;
 
-import matsu.num.transform.fft.validation.StructureAcceptance;
-
 /**
  * 任意のデータサイズに適用可能なDST-2.
  * 
@@ -34,15 +32,4 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
 @Deprecated(forRemoval = true)
 public interface GenericDST2Executor extends DST2Executor {
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link GenericDST2Executor} でaccept条件とreject条件が共に確定 (固定) される.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/GenericDST3Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/GenericDST3Executor.java
@@ -6,8 +6,6 @@
  */
 package matsu.num.transform.fft.dctdst;
 
-import matsu.num.transform.fft.validation.StructureAcceptance;
-
 /**
  * 任意のデータサイズに適用可能なDST-3.
  * 
@@ -34,15 +32,4 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
 @Deprecated(forRemoval = true)
 public interface GenericDST3Executor extends DST3Executor {
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link GenericDST3Executor} でaccept条件とreject条件が共に確定 (固定) される.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/dctdst/GenericDST4Executor.java
+++ b/src/matsu/num/transform/fft/dctdst/GenericDST4Executor.java
@@ -6,8 +6,6 @@
  */
 package matsu.num.transform.fft.dctdst;
 
-import matsu.num.transform.fft.validation.StructureAcceptance;
-
 /**
  * 任意のデータサイズに適用可能なDST-4.
  * 
@@ -34,15 +32,4 @@ import matsu.num.transform.fft.validation.StructureAcceptance;
 @Deprecated(forRemoval = true)
 public interface GenericDST4Executor extends DST4Executor {
 
-    /**
-     * {@inheritDoc}
-     * 
-     * <p>
-     * {@link GenericDST4Executor} でaccept条件とreject条件が共に確定 (固定) される.
-     * </p>
-     * 
-     * @throws NullPointerException {@inheritDoc}
-     */
-    @Override
-    public abstract StructureAcceptance accepts(double[] data);
 }

--- a/src/matsu/num/transform/fft/service/CyclicConvolutionTypes.java
+++ b/src/matsu/num/transform/fft/service/CyclicConvolutionTypes.java
@@ -5,10 +5,11 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.6.19
+ * 2025.6.20
  */
 package matsu.num.transform.fft.service;
 
+import matsu.num.transform.fft.convolution.CyclicConvolutionExecutor;
 import matsu.num.transform.fft.convolution.impl.GenericCyclicConvolutionExecutor;
 import matsu.num.transform.fft.convolution.impl.Power2CyclicConvolutionExecutor;
 
@@ -31,12 +32,25 @@ public final class CyclicConvolutionTypes {
 
     /**
      * 任意サイズの実数列に対応する巡回畳み込みの実行手段を表す.
+     * 
+     * <p>
+     * {@link CyclicConvolutionExecutor#accepts(double[], double[])}
+     * で受け入れられる入力は, <br>
+     * {@link CyclicConvolutionExecutor} と同一である.
+     * </p>
      */
     public static final ExecutorType<
             matsu.num.transform.fft.convolution.GenericCyclicConvolutionExecutor> GENERIC_CYCLIC_CONVOLUTION_EXECUTOR;
 
     /**
      * 2の累乗サイズの実数列に対応する巡回畳み込みの実行手段を表す.
+     * 
+     * <p>
+     * {@link CyclicConvolutionExecutor#accepts(double[], double[])}
+     * で受け入れられる入力は, <br>
+     * {@link CyclicConvolutionExecutor} に加えて
+     * 2の累乗サイズでなければならない.
+     * </p>
      */
     public static final ExecutorType<
             matsu.num.transform.fft.convolution.Power2CyclicConvolutionExecutor> POWER2_CYCLIC_CONVOLUTION_EXECUTOR;

--- a/src/matsu/num/transform/fft/service/DctDstTypes.java
+++ b/src/matsu/num/transform/fft/service/DctDstTypes.java
@@ -5,10 +5,18 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.6.19
+ * 2025.6.20
  */
 package matsu.num.transform.fft.service;
 
+import matsu.num.transform.fft.dctdst.DCT1Executor;
+import matsu.num.transform.fft.dctdst.DCT2Executor;
+import matsu.num.transform.fft.dctdst.DCT3Executor;
+import matsu.num.transform.fft.dctdst.DCT4Executor;
+import matsu.num.transform.fft.dctdst.DST1Executor;
+import matsu.num.transform.fft.dctdst.DST2Executor;
+import matsu.num.transform.fft.dctdst.DST3Executor;
+import matsu.num.transform.fft.dctdst.DST4Executor;
 import matsu.num.transform.fft.dctdst.impl.GenericDCT1Executor;
 import matsu.num.transform.fft.dctdst.impl.GenericDCT2Executor;
 import matsu.num.transform.fft.dctdst.impl.GenericDCT3Executor;
@@ -37,41 +45,89 @@ public final class DctDstTypes {
 
     /**
      * 任意サイズに対応するDCT-1の実行手段を表す.
+     * 
+     * <p>
+     * {@link DCT1Executor#accepts(double[])}
+     * で受け入れられる入力は, <br>
+     * {@link DCT1Executor} と同一である.
+     * </p>
      */
     public static final ExecutorType<matsu.num.transform.fft.dctdst.GenericDCT1Executor> GENERIC_DCT1_EXECUTOR;
 
     /**
      * 任意サイズに対応するDCT-2の実行手段を表す.
+     * 
+     * <p>
+     * {@link DCT2Executor#accepts(double[])}
+     * で受け入れられる入力は, <br>
+     * {@link DCT2Executor} と同一である.
+     * </p>
      */
     public static final ExecutorType<matsu.num.transform.fft.dctdst.GenericDCT2Executor> GENERIC_DCT2_EXECUTOR;
 
     /**
      * 任意サイズに対応するDCT-3の実行手段を表す.
+     * 
+     * <p>
+     * {@link DCT3Executor#accepts(double[])}
+     * で受け入れられる入力は, <br>
+     * {@link DCT3Executor} と同一である.
+     * </p>
      */
     public static final ExecutorType<matsu.num.transform.fft.dctdst.GenericDCT3Executor> GENERIC_DCT3_EXECUTOR;
 
     /**
      * 任意サイズに対応するDCT-4の実行手段を表す.
+     * 
+     * <p>
+     * {@link DCT4Executor#accepts(double[])}
+     * で受け入れられる入力は, <br>
+     * {@link DCT4Executor} と同一である.
+     * </p>
      */
     public static final ExecutorType<matsu.num.transform.fft.dctdst.GenericDCT4Executor> GENERIC_DCT4_EXECUTOR;
 
     /**
      * 任意サイズに対応するDST-1の実行手段を表す.
+     * 
+     * <p>
+     * {@link DST1Executor#accepts(double[])}
+     * で受け入れられる入力は, <br>
+     * {@link DST1Executor} と同一である.
+     * </p>
      */
     public static final ExecutorType<matsu.num.transform.fft.dctdst.GenericDST1Executor> GENERIC_DST1_EXECUTOR;
 
     /**
      * 任意サイズに対応するDST-2の実行手段を表す.
+     * 
+     * <p>
+     * {@link DST2Executor#accepts(double[])}
+     * で受け入れられる入力は, <br>
+     * {@link DST2Executor} と同一である.
+     * </p>
      */
     public static final ExecutorType<matsu.num.transform.fft.dctdst.GenericDST2Executor> GENERIC_DST2_EXECUTOR;
 
     /**
      * 任意サイズに対応するDST-3の実行手段を表す.
+     * 
+     * <p>
+     * {@link DST3Executor#accepts(double[])}
+     * で受け入れられる入力は, <br>
+     * {@link DST3Executor} と同一である.
+     * </p>
      */
     public static final ExecutorType<matsu.num.transform.fft.dctdst.GenericDST3Executor> GENERIC_DST3_EXECUTOR;
 
     /**
      * 任意サイズに対応するDST-4の実行手段を表す.
+     * 
+     * <p>
+     * {@link DST4Executor#accepts(double[])}
+     * で受け入れられる入力は, <br>
+     * {@link DST4Executor} と同一である.
+     * </p>
      */
     public static final ExecutorType<matsu.num.transform.fft.dctdst.GenericDST4Executor> GENERIC_DST4_EXECUTOR;
 

--- a/src/matsu/num/transform/fft/service/DftTypes.java
+++ b/src/matsu/num/transform/fft/service/DftTypes.java
@@ -5,12 +5,15 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.6.19
+ * 2025.6.20
  */
 package matsu.num.transform.fft.service;
 
+import matsu.num.transform.fft.DFTExecutor;
+import matsu.num.transform.fft.IDFTExecutor;
 import matsu.num.transform.fft.dft.impl.GenericDFTExecutor;
 import matsu.num.transform.fft.dft.impl.GenericIDFTExecutor;
+import matsu.num.transform.fft.dto.ComplexNumberArrayDTO;
 
 /**
  * {@link ExecutorType} 型の離散Fourier変換と逆変換に関する定数を取りまとめるクラス.
@@ -31,11 +34,23 @@ public final class DftTypes {
 
     /**
      * 任意サイズに対応するDFTの実行手段を表す.
+     * 
+     * <p>
+     * {@link DFTExecutor#accepts(ComplexNumberArrayDTO)}
+     * で受け入れられる入力は, <br>
+     * {@link DFTExecutor} と同一である.
+     * </p>
      */
     public static final ExecutorType<matsu.num.transform.fft.GenericDFTExecutor> GENERIC_DFT_EXECUTOR;
 
     /**
      * 任意サイズに対応するIDFTの実行手段を表す.
+     * 
+     * <p>
+     * {@link IDFTExecutor#accepts(ComplexNumberArrayDTO)}
+     * で受け入れられる入力は, <br>
+     * {@link IDFTExecutor} と同一である.
+     * </p>
      */
     public static final ExecutorType<matsu.num.transform.fft.GenericIDFTExecutor> GENERIC_IDFT_EXECUTOR;
 


### PR DESCRIPTION
Squashed commit of the following:

    docs: DST,DCTのExecutorに関する契約を, 次世代バージョン用に修正

    docs: DFTExecutor,IDFTExecutorに関する契約を, 次世代バージョン用に修正

    docs: CyclicConvolutionExecutorに関する契約を, 次世代バージョン用に修正